### PR TITLE
fix: scrolling on Landscape iOS safari & Chrome

### DIFF
--- a/packages/Modal/styles.scss
+++ b/packages/Modal/styles.scss
@@ -106,6 +106,9 @@
 
   transition: 0.2s all;
 
+  overflow-y: scroll;
+  max-height: 100%;
+  
   &:global(.enter) {
     opacity: 0;
   }


### PR DESCRIPTION
These additions fix the missing view port area on the bottom of the screen, so no content will be hidden